### PR TITLE
Fixed objToHash and Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,18 +2,18 @@ module.exports = function(grunt) {
 
   "use strict";
 
-  grunt.initConfig({ 
-  
+  grunt.initConfig({
+
     libFiles: [
       "src/**/*.purs",
       "bower_components/purescript-*/src/**/*.purs",
     ],
-    
+
     clean: {
       tests: ["tmp"],
       lib:   ["output"]
     },
-  
+
     pscMake: ["<%=libFiles%>"],
     dotPsci: ["<%=libFiles%>"],
     docgen: {
@@ -26,7 +26,7 @@ module.exports = function(grunt) {
     psc: {
       tests: {
         options: {
-          module: ["Main"],
+          modules: ["Main"],
           main: true
         },
         src: ["tests/Test.purs", "<%=libFiles%>"],
@@ -34,7 +34,7 @@ module.exports = function(grunt) {
       },
       example_simple: {
          options: {
-          module: ["Main"],
+          modules: ["Main"],
           main: true
         },
         src: ["examples/Simple.purs", "<%=libFiles%>"],
@@ -42,7 +42,7 @@ module.exports = function(grunt) {
       },
       example_complex: {
          options: {
-          module: ["Main"],
+          modules: ["Main"],
           main: true
         },
         src: ["examples/Complex.purs", "<%=libFiles%>"],
@@ -68,7 +68,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks("grunt-contrib-clean");
   grunt.loadNpmTasks("grunt-purescript");
   grunt.loadNpmTasks("grunt-execute");
-  
+
   grunt.registerTask("test", ["clean:tests", "psc:tests", "execute:tests"]);
   grunt.registerTask("make", ["pscMake", "dotPsci", "docgen"]);
   grunt.registerTask("example_simple",  ["psc:example_simple",  "execute:example_simple"]);

--- a/src/Data/JSON.purs
+++ b/src/Data/JSON.purs
@@ -276,16 +276,19 @@ foreign import unsafeCoerce "function unsafeCoerce (a) {return a;}"
     :: forall a b. a -> b
 
 foreign import objToHash
-    "function objToHash (obj) {\
+    "function objToHash (fst, snd, obj) {\
     \    var hash = {};\
     \    for(var i = 0; i < obj.length; i++) {\
-    \        hash[Data_Tuple.fst(obj[i])] = valueToJSONImpl(Data_Tuple.snd(obj[i]));\
+    \        hash[fst(obj[i])] = valueToJSONImpl(snd(obj[i]));\
     \    }\
     \    return hash;\
-    \}" :: [Tuple String JValue] -> JSON
+    \}" :: Fn3 (Tuple String JValue -> String)
+               (Tuple String JValue -> JValue)
+               [Tuple String JValue]
+               JSON
 
 valueToJSONImpl :: JValue -> JSON
-valueToJSONImpl (JObject o) = objToHash $ M.toList o
+valueToJSONImpl (JObject o) = runFn3 objToHash fst snd $ M.toList o
 valueToJSONImpl (JArray  a) = unsafeCoerce $ valueToJSONImpl <$> a
 valueToJSONImpl (JString s) = unsafeCoerce s
 valueToJSONImpl (JNumber n) = unsafeCoerce n


### PR DESCRIPTION
Hi, it's me again:) Seems like I've left unfixed `objToHash` fn. And I've found out why tests in my app were crashing while trying to reproduce them right here gave nothing: the thing is that in `psc` task in Gruntfile option that contains list of modules to optimize is caled `modules` instead of `module` param in psc itself. Thus there were no optimizations for tests and examples in ps-json and all functions were present in all imported modules. But when optimizations are enabled functions that are not directly used are being deleted. In `objToHash` there were `fst` and `snd` which weren't used anywhere else in Data.JSON so they've been optimized out giving nasty runtime errors. I've fixed it too.
