### PR TITLE
Remove unnecessary Ord constraint from mapFromJSON

### DIFF
--- a/src/Data/JSON.purs
+++ b/src/Data/JSON.purs
@@ -106,7 +106,7 @@ instance maybeFromJSON :: (FromJSON a) => FromJSON (Maybe a) where
 instance setFromJSON :: (Ord a, FromJSON a) => FromJSON (S.Set a) where
     parseJSON a = S.fromList <$> parseJSON a
 
-instance mapFromJSON :: (Ord a, FromJSON a) => FromJSON (M.Map String a) where
+instance mapFromJSON :: (FromJSON a) => FromJSON (M.Map String a) where
     parseJSON (JObject o) = M.fromList <$> (sequence $ fn <$> M.toList o)
       where
         fn (Tuple k v) = case parseJSON v of


### PR DESCRIPTION
The Ord constraint prevents you from parsing something like the following:

{"foos": [{"fooValue": 7}, {"fooValue: 8}]}

data Foo = Foo [Number]
instance fromJSONFoo :: FromJSON Foo where
  parseJSON (JObject o) = Foo <$> ((o .: "foos") >>= traverse (.: "fooValue"))

This doesn't work because there's no instance for Ord JValue, so no instance for FromJSON (JObject = Map String JValue), so no instance for FromJSON [JObject].