### PR TITLE
PS 0.7 changes.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,13 +20,13 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-sets": "~0.2.0",
-    "purescript-maps": "~0.2.0",
-    "purescript-maybe": "~0.2.1",
-    "purescript-tuples": "~0.2.3",
-    "purescript-either": "~0.1.4",
-    "purescript-foldable-traversable": "~0.2.1",
-    "purescript-exceptions": "~0.2.2"
+    "purescript-sets": "~0.4.0",
+    "purescript-maps": "~0.4.0",
+    "purescript-maybe": "~0.3.2",
+    "purescript-tuples": "~0.4.0",
+    "purescript-either": "~0.2.0",
+    "purescript-foldable-traversable": "~0.4.0",
+    "purescript-exceptions": "~0.3.0"
   },
   "devDependencies": {
     "purescript-simple-assert": "~0.2.1",

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "gulp-foreach": "^0.1.0",
     "gulp-mocha": "^2.0.0",
     "gulp-purescript": "^0.1.2"
+  },
+  "dependencies": {
+    "gulp-purescript": "^0.5.0"
   }
 }

--- a/src/Data/JSON.js
+++ b/src/Data/JSON.js
@@ -1,4 +1,4 @@
-/* global exports */
+  /* global exports */
 "use strict";
 
 // module Data.JSON
@@ -61,7 +61,7 @@ exports.unsafeCoerce = function unsafeCoerce(a) {
   return a;
 };
 
-exports.objToHash = function objToHash(fst, snd, obj) {
+exports.objToHash = function objToHash(valueToJSONImpl, fst, snd, obj) {
     var hash = {};
     for(var i = 0; i < obj.length; i++) {
         hash[fst(obj[i])] = valueToJSONImpl(snd(obj[i]));

--- a/src/Data/JSON.js
+++ b/src/Data/JSON.js
@@ -1,0 +1,74 @@
+/* global exports */
+"use strict";
+
+// module Data.JSON
+
+exports.jsonParseImpl = function jsonParseImpl(left, right, string) {
+    try       { return right(JSON.parse(string)); }
+    catch (e) { return left(e.toString()); }
+};
+
+exports.jsonToValueImpl = function jsonToValueImpl(auxes, ctors) {
+    var left   = auxes.left;
+    var right  = auxes.right;
+    var either = auxes.either;
+    var insert = auxes.insert;
+    var empty  = auxes.empty;
+    var Null   = ctors.null;
+    var Number = ctors.number;
+    var Bool   = ctors.bool;
+    var String = ctors.string;
+    var Array  = ctors.array;
+    var Object = ctors.object;
+    var parse  = function(json) {
+        var typ = Object.prototype.toString.call(json).slice(8,-1);
+        if (typ === 'Number') {
+            return right(Number(json));
+        } else if (typ === 'Boolean') {
+            return right(Bool(json));
+        } else if (typ === 'String') {
+            return right(String(json));
+        } else if (typ === 'Null') {
+            return right(Null);
+        } else if (typ === 'Array') {
+            var ary = [];
+            for(var i = 0; i < json.length; i++) {
+                either
+                    (function(l){return left(l)})
+                    (function(r){ary.push(r)})
+                    (parse(json[i]))
+            }
+            return right(Array(ary));
+        } else if (typ === 'Object') {
+            var obj = empty;
+            for(var k in json) {
+                either
+                    (function(l){return left(l)})
+                    (function(r){obj = insert(k)(r)(obj)})
+                    (parse(json[k]));
+            }
+            return right(Object(obj));
+        } else {
+            return left('unknown type: ' + typ);
+        }
+   };
+   return parse;
+};
+
+exports.jsNull = null;
+
+exports.unsafeCoerce = function unsafeCoerce(a) {
+  return a;
+};
+
+exports.objToHash = function objToHash(fst, snd, obj) {
+    var hash = {};
+    for(var i = 0; i < obj.length; i++) {
+        hash[fst(obj[i])] = valueToJSONImpl(snd(obj[i]));
+    }
+    return hash;
+};
+
+exports.jsonStringify = function jsonStringify(json) {
+  return JSON.stringify(json);
+};

--- a/src/Data/JSON.purs
+++ b/src/Data/JSON.purs
@@ -214,13 +214,14 @@ instance valueToJSON :: ToJSON JValue where
 foreign import jsNull :: JSON
 foreign import unsafeCoerce :: forall a b. a -> b
 
-foreign import objToHash :: Fn3 (Tuple String JValue -> String)
+foreign import objToHash :: Fn4 (JValue -> JSON)
+               (Tuple String JValue -> String)
                (Tuple String JValue -> JValue)
                (Array (Tuple String JValue))
                JSON
 
 valueToJSONImpl :: JValue -> JSON
-valueToJSONImpl (JObject o) = runFn3 objToHash fst snd $ fromList $ M.toList o
+valueToJSONImpl (JObject o) = runFn4 objToHash valueToJSONImpl fst snd $ fromList $ M.toList o
 valueToJSONImpl (JArray  a) = unsafeCoerce $ valueToJSONImpl <$> a
 valueToJSONImpl (JString s) = unsafeCoerce s
 valueToJSONImpl (JNumber n) = unsafeCoerce n

--- a/tests/Test.purs
+++ b/tests/Test.purs
@@ -3,8 +3,6 @@ module Test.Main where
 import Control.Monad.Eff
 import Control.Monad.Eff.Exception
 
-import Debug.Trace
-
 import qualified Data.Set as S
 import qualified Data.Map as M
 import Data.Tuple
@@ -28,7 +26,7 @@ main = runMocha $ do
     itDecode "Boolean" $ Just true @=? (decode "true" :: Maybe Boolean)
     itDecode "Unit"    $ Just unit @=? (decode "null" :: Maybe Unit)
 
-    itDecode "Array"   $ Just [1,2,3,2,1] @=? (decode "[1,2,3,2,1]" :: Maybe [Number])
+    itDecode "Array"   $ Just [1,2,3,2,1] @=? (decode "[1,2,3,2,1]" :: Maybe (Array Number))
     itDecode "Set"     $ Just (S.fromList [1,2,3]) @=? (decode "[1,2,3,2,1]" :: Maybe (S.Set Number))
     itDecode "Tuple"   $ Just (Tuple "kevin" 18)   @=? (decode "[\"kevin\", 18]" :: Maybe (Tuple String Number))
     itDecode "Map"     $ Just (M.fromList [Tuple "a" 3, Tuple "b" 2]) @=? (decode "{\"a\": 1, \"b\": 2, \"a\": 3}" :: Maybe (M.Map String Number))


### PR DESCRIPTION
Hopefully this is a start, but:

* Tests won't run as purescript-simple-assert (& purescript-assertion-error) and purescript-pspec aren't up to date for 0.7
* Since `Data.Map.toList` and `fromList` now actually use lists rather than arrays and there is no array version, a few functions now go array -> list -> map etc - probably there is a better and more performant way